### PR TITLE
PRごとにPDFをGoogle Driveに保存する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ jobs:
         user: root
         environment:
           REVIEWDOG_VERSION: 0.9.12
-      - image: circleci/golang:1.12.7
     steps:
       - checkout
       - restore_cache:
@@ -40,9 +39,8 @@ jobs:
           name: Move PDF
           command: |
             mkdir ./build
-            mv ./articles/golangtokyo_shoten7.pdf ./build/$(CIRCLE_BRANCH).pdf
+            mv ./articles/golangtokyo_shoten7.pdf ./build/${CIRCLE_BRANCH}.pdf
             ls ./build
-            go version
           #       - store_artifacts:
           #           path: ./articles/golangtokyo_shoten7.pdf
           #           destination: golangtokyo_shoten7.pdf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2
 jobs:
   build:
     docker:
-      - image: vvakame/review:3.1
+      # vvakame/review imageにgdriveのmasterブランチをgo getしたものを含んだimage
+      - image: budougumi0617/review-uploader:latest
         user: root
         environment:
           REVIEWDOG_VERSION: 0.9.12
@@ -38,9 +39,11 @@ jobs:
       - run:
           name: Move PDF
           command: |
-            mkdir ./build
-            mv ./articles/golangtokyo_shoten7.pdf ./build/${CIRCLE_BRANCH}.pdf
-            ls ./build
-          #       - store_artifacts:
-          #           path: ./articles/golangtokyo_shoten7.pdf
-          #           destination: golangtokyo_shoten7.pdf
+            mv ./articles/golangtokyo_shoten7.pdf ./${CIRCLE_BRANCH}.pdf
+      - run:
+          name: Upload PDF
+          command: |
+            # 環境変数から認証情報を取得してJSONファイルに出力
+            echo $GOOGLE_SERVICE_ACCOUNT_CREDENTIAL > credential.json
+            # Upload to https://drive.google.com/drive/u/0/folders/15vJsSbnosM-iXE0VogU71boPzrHiYnWr
+            gdrive --config $(pwd) --service-account credential.json upload -p 15vJsSbnosM-iXE0VogU71boPzrHiYnWr ./${CIRCLE_BRANCH}.pdf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
         user: root
         environment:
           REVIEWDOG_VERSION: 0.9.12
+      - image: circleci/golang:1.12.7
     steps:
       - checkout
       - restore_cache:
@@ -35,6 +36,13 @@ jobs:
       - run:
           name: Build PDF
           command: npm run pdf
+      - run:
+          name: Move PDF
+          command: |
+            mkdir ./build
+            mv ./articles/golangtokyo_shoten7.pdf ./build/$(CIRCLE_BRANCH).pdf
+            ls ./build
+            go version
           #       - store_artifacts:
           #           path: ./articles/golangtokyo_shoten7.pdf
           #           destination: golangtokyo_shoten7.pdf

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+# PRの概要
+(見てほしい点などこのPRの要点を書いてください)
+
+
+# PDFを確認する
+PRの内容はPDFにビルドされて次のURLのGoogle Driveディレクトリ以下に格納されます（要アクセス権限）。
+
+*TODO 同じ名前のファイルが何個も作成されてしまうのでどうにかする*
+
+https://drive.google.com/drive/u/0/folders/15vJsSbnosM-iXE0VogU71boPzrHiYnWr


### PR DESCRIPTION
# 概要
毎回ローカルでビルドしないでもPDFを確認できるように、Google Driveに完成物をアップロードするCircleCIの設定を行う。